### PR TITLE
Fix make install failing due to whitespace in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .NOTPARALLEL:
 
 prefix ?= /usr/local
-override prefix := $(prefix:%/=%)  # remove trailing /
+# remove trailing /
+override prefix := $(prefix:%/=%)
 DIRS = src simple test
 
 BUILDDIRS = $(DIRS:%=build-%)


### PR DESCRIPTION
The command `make install` is failing with following error:
```
install -d /usr/local  /include
install: cannot change permissions of ‘/include’: No such file or directory
```

This indicates a whitespace in the path which shouldn't be there.

This PR fixes that.