### PR TITLE
Replace non-standard escape sequence \e with \033

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -1615,7 +1615,7 @@ static int parse_norm(parser_t *pp, token_t tok, span_t *ret_span) {
       p += 2;
       continue;
     case 'e':
-      *dst++ = '\e';
+      *dst++ = '\033';
       p += 2;
       continue;
     case 'x': {


### PR DESCRIPTION
\e gives a compiler warning as it is non-standard. Changing it to \033 fixes this