### PR TITLE
fix integer overflow in read_int()

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -2060,15 +2060,14 @@ static bool is_valid_timezone(int minute) {
 // Read an int (without signs) from the string p.
 static int read_int(const char *p, int *ret) {
   const char *pp = p;
-  int val = 0;
+  int64_t val = 0;
   for (; isdigit(*p); p++) {
-    int digit = *p - '0';
-    if (val > (INT_MAX - digit) / 10) {
+    val = val * 10 + (*p - '0');
+    if (val > INT_MAX) {
       return 0; // overflowed
     }
-    val = val * 10 + digit;
   }
-  *ret = val;
+  *ret = (int)val;
   return p - pp;
 }
 

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -2062,10 +2062,11 @@ static int read_int(const char *p, int *ret) {
   const char *pp = p;
   int val = 0;
   for (; isdigit(*p); p++) {
-    val = val * 10u + (*p - '0');
-    if (val < 0) {
+    int digit = *p - '0';
+    if (val > (INT_MAX - digit) / 10) {
       return 0; // overflowed
     }
+    val = val * 10 + digit;
   }
   *ret = val;
   return p - pp;


### PR DESCRIPTION
## Summary

- `read_int()` used `val * 10u + digit` (unsigned arithmetic), so the overflow check `if (val < 0)` never triggered — signed overflow was undefined behavior and in practice silently wrapped
- Replaced with a pre-check `if (val > (INT_MAX - digit) / 10)` before accumulating each digit

## Test plan

- [x] `make DEBUG=1` — builds clean with ASAN/UBSAN
- [x] All 214 valid + 466 invalid TOML tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)