### PR TITLE
guard against size overflow in tab_emplace()

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -267,6 +267,10 @@ static toml_datum_t *tab_emplace(toml_datum_t *tab, span_t key,
 
   // Expand pkey[], plen[] and value[].
   int N = tab->u.tab.size;
+  if (N > (INT_MAX / (int)sizeof(*tab->u.tab.key)) - 8) {
+    *reason = "table too large";
+    return NULL;
+  }
   {
     char **pkey = REALLOC(tab->u.tab.key, sizeof(*pkey) * align8(N + 1));
     int *plen = REALLOC(tab->u.tab.len, sizeof(*plen) * align8(N + 1));

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -138,6 +138,7 @@ static int ucs_to_utf8(uint32_t code, char buf[4]);
 // stack overflow during recursive descent of the parser.
 #define BRACKET_LEVEL_MAX 30
 #define BRACE_LEVEL_MAX 30
+#define TABLE_MAX (1 << 16)
 
 static inline size_t align8(size_t x) { return (((x) + 7) & ~7); }
 
@@ -267,7 +268,7 @@ static toml_datum_t *tab_emplace(toml_datum_t *tab, span_t key,
 
   // Expand pkey[], plen[] and value[].
   int N = tab->u.tab.size;
-  if (N > (INT_MAX / (int)sizeof(*tab->u.tab.key)) - 8) {
+  if (N >= TABLE_MAX) {
     *reason = "table too large";
     return NULL;
   }


### PR DESCRIPTION
## Summary

- `sizeof(*pkey) * align8(N + 1)` could silently overflow when a TOML table contains a very large number of keys, leading to an undersized allocation
- Added a bounds check on `N` before the realloc block; returns `"table too large"` error if exceeded

## Test plan

- [x] `make DEBUG=1` — builds clean with ASAN/UBSAN
- [x] All 214 valid + 466 invalid TOML tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)