### PR TITLE
assert keypart.nspan > 0 before pre-decrement

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -1197,6 +1197,7 @@ static int parse_inline_table(parser_t *pp, token_t tok,
     DO(parse_key(pp, tok, &keypart));
 
     // Descend to one keypart before last
+    assert(keypart.nspan > 0);
     span_t lastkeypart = keypart.span[--keypart.nspan];
     toml_datum_t *tab =
         descend_keypart(pp, keylineno, ret_datum, &keypart, false);
@@ -1379,6 +1380,7 @@ static int parse_array_table_expr(parser_t *pp, token_t tok) {
   }
 
   // remove the last keypart from keypart[]
+  assert(keypart.nspan > 0);
   span_t lastkeypart = keypart.span[--keypart.nspan];
 
   // descend the key from the toptab


### PR DESCRIPTION
## Summary

- `keypart.span[--keypart.nspan]` at two sites in the parser is safe because `parse_key()` guarantees at least one keypart, but this invariant is non-obvious from reading the code
- Added `assert(keypart.nspan > 0)` before each pre-decrement to document and enforce the assumption

## Test plan

- [x] `make DEBUG=1` — builds clean with ASAN/UBSAN
- [x] All 214 valid + 466 invalid TOML tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)