### PR TITLE
enforce ARRAY_MAX (2^14) limit in arr_emplace()

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -139,6 +139,7 @@ static int ucs_to_utf8(uint32_t code, char buf[4]);
 #define BRACKET_LEVEL_MAX 30
 #define BRACE_LEVEL_MAX 30
 #define TABLE_MAX (1 << 16)
+#define ARRAY_MAX (1 << 14)
 
 static inline size_t align8(size_t x) { return (((x) + 7) & ~7); }
 
@@ -329,6 +330,10 @@ static int tab_add(toml_datum_t *tab, span_t newkey, toml_datum_t newvalue,
 static toml_datum_t *arr_emplace(toml_datum_t *arr, const char **reason) {
   assert(arr->type == TOML_ARRAY);
   int n = arr->u.arr.size;
+  if (n >= ARRAY_MAX) {
+    *reason = "array too large";
+    return NULL;
+  }
   toml_datum_t *elem = REALLOC(arr->u.arr.elem, sizeof(*elem) * align8(n + 1));
   if (!elem) {
     *reason = "out of memory";


### PR DESCRIPTION
## Summary

- Adds `ARRAY_MAX (1 << 14)` constant (16k elements) alongside the existing `TABLE_MAX`
- Enforces the limit in `arr_emplace()` with an early-return and `"array too large"` error message, mirroring the guard in `tab_emplace()`

## Test plan

- [ ] All 680 valid/invalid stdtest cases pass unchanged
- [ ] Verify that a TOML file with an array exceeding 16k elements is rejected with a parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)