### PR TITLE
fix: copy table keys into merged pool in toml_merge

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -472,7 +472,13 @@ static int datum_copy(toml_datum_t *dst, toml_datum_t src, pool_t *pool,
     break;
   case TOML_TABLE:
     for (int i = 0; i < src.u.tab.size; i++) {
-      span_t newkey = {src.u.tab.key[i], src.u.tab.len[i]};
+      char *keycopy = pool_alloc(pool, src.u.tab.len[i] + 1);
+      if (!keycopy) {
+        *reason = "out of memory";
+        goto bail;
+      }
+      memcpy(keycopy, src.u.tab.key[i], src.u.tab.len[i] + 1);
+      span_t newkey = {keycopy, src.u.tab.len[i]};
       toml_datum_t *pvalue = tab_emplace(dst, newkey, reason);
       if (!pvalue) {
         goto bail;
@@ -526,8 +532,14 @@ static int datum_merge(toml_datum_t *dst, toml_datum_t src, pool_t *pool,
     // for key-value in src:
     //    override key-value in dst.
     for (int i = 0; i < src.u.tab.size; i++) {
+      char *keycopy = pool_alloc(pool, src.u.tab.len[i] + 1);
+      if (!keycopy) {
+        *reason = "out of memory";
+        return -1;
+      }
+      memcpy(keycopy, src.u.tab.key[i], src.u.tab.len[i] + 1);
       span_t key;
-      key.ptr = src.u.tab.key[i];
+      key.ptr = keycopy;
       key.len = src.u.tab.len[i];
       toml_datum_t *pvalue = tab_emplace(dst, key, reason);
       if (!pvalue) {

--- a/test/merge/test1.c
+++ b/test/merge/test1.c
@@ -157,6 +157,32 @@ static void test_empty_documents() {
   check("", "", "");
 }
 
+// Merged result must own its keys: tomlc17 requires each result be freed
+// independently, so reading the merged tree after freeing the inputs must
+// not touch the freed input pools.
+static void test_keys_outlive_inputs() {
+  printf("Running test_keys_outlive_inputs...\n");
+  const char *doc1 = "[owner]\n"
+                     "name = \"Alice\"\n";
+  const char *doc2 = "[owner]\n"
+                     "organization = \"ACME\"\n";
+  toml_result_t r1 = toml_parse(doc1, strlen(doc1));
+  toml_result_t r2 = toml_parse(doc2, strlen(doc2));
+  toml_result_t merged = toml_merge(&r1, &r2);
+  CHECK(merged.ok);
+
+  toml_free(r1);
+  toml_free(r2);
+
+  toml_datum_t owner = toml_get(merged.toptab, "owner");
+  toml_datum_t name = toml_get(owner, "name");
+  toml_datum_t org = toml_get(owner, "organization");
+  CHECK(name.type == TOML_STRING && 0 == strcmp(name.u.str.ptr, "Alice"));
+  CHECK(org.type == TOML_STRING && 0 == strcmp(org.u.str.ptr, "ACME"));
+
+  toml_free(merged);
+}
+
 int main() {
   test_simple_merge();
   test_overwrite_values();
@@ -167,6 +193,7 @@ int main() {
   test_array_of_tables();
   test_type_conflicts();
   test_empty_documents();
+  test_keys_outlive_inputs();
 
   printf("All tests completed.\n");
   return 0;


### PR DESCRIPTION
tab_emplace stores key pointers without copying, so datum_copy and datum_merge aliased the merged tree's keys into the source pools. Freeing an input after merge dangled those keys -> use-after-free.

Copy each key into the merged pool, like string values already are. Pool size (r1->top + r2->top) stays a valid upper bound.

Adds test_keys_outlive_inputs: aborts under ASan without the fix.