### PR TITLE
compare tables as unordered maps in toml_equiv

### DIFF
--- a/API.md
+++ b/API.md
@@ -272,8 +272,9 @@ with `toml_free()` independently.
 bool toml_equiv(const toml_result_t *r1, const toml_result_t *r2);
 ```
 
-Return `true` if the two results represent identical documents. Table key order
-and array element order are both significant.
+Return `true` if the two results represent identical documents. Tables are
+compared as unordered maps (keys matched by name); array element order is
+significant.
 
 ---
 

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -675,19 +675,26 @@ static bool datum_equiv(toml_datum_t a, toml_datum_t b) {
     }
     return true;
   case TOML_TABLE:
+    // Tables are unordered maps: match each key of a against any key of b,
+    // not positionally. Equal sizes plus a full one-way key match implies a
+    // bijection because keys are unique within a table.
     N = a.u.tab.size;
     if (N != b.u.tab.size) {
       return false;
     }
     for (int i = 0; i < N; i++) {
       int len = a.u.tab.len[i];
-      if (len != b.u.tab.len[i]) {
+      int j = 0;
+      for (; j < N; j++) {
+        if (len == b.u.tab.len[j] &&
+            0 == memcmp(a.u.tab.key[i], b.u.tab.key[j], len)) {
+          break;
+        }
+      }
+      if (j == N) {
         return false;
       }
-      if (0 != memcmp(a.u.tab.key[i], b.u.tab.key[i], len)) {
-        return false;
-      }
-      if (!datum_equiv(a.u.tab.value[i], b.u.tab.value[i])) {
+      if (!datum_equiv(a.u.tab.value[i], b.u.tab.value[j])) {
         return false;
       }
     }

--- a/src/tomlc17.h
+++ b/src/tomlc17.h
@@ -234,7 +234,8 @@ TOML_EXTERN toml_result_t toml_merge(const toml_result_t *r1,
 /**
  * @brief Compare two TOML results for equality.
  *
- * Comparison is sensitive to the order of elements in arrays and tables.
+ * Tables compare as unordered maps (keys matched by name); array element
+ * order is significant.
  *
  * @param r1 The first TOML result.
  * @param r2 The second TOML result.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 .NOTPARALLEL:
 
 # disable merge tests for now
-DIRS := scankey scanvalue parser merge cpp stdtest source
+DIRS := scankey scanvalue parser merge cpp stdtest source equiv
 
 BUILDDIRS = $(DIRS:%=build-%)
 CLEANDIRS = $(DIRS:%=clean-%)

--- a/test/equiv/Makefile
+++ b/test/equiv/Makefile
@@ -1,0 +1,27 @@
+CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD
+
+EXEC = test1
+
+all: $(EXEC)
+
+test1: test1.c
+	$(CC) $(CFLAGS) -o $@ $@.c
+
+test: all
+	@echo
+	@echo =========================
+	@echo == equiv test
+	@echo =========================
+	./test1
+
+-include test1.d
+
+clean:
+	rm -f *.o *.d $(EXEC)
+
+distclean: clean
+
+format:
+	clang-format -i *.[ch]
+
+.PHONY: all clean distclean format test

--- a/test/equiv/test1.c
+++ b/test/equiv/test1.c
@@ -1,0 +1,90 @@
+#include "../../src/tomlc17.c"
+
+static void failed() {
+  printf("FAILED\n");
+  exit(1);
+}
+
+#define CHECK(x)                                                               \
+  if (x)                                                                       \
+    ;                                                                          \
+  else                                                                         \
+    failed()
+
+static bool equiv(const char *doc1, const char *doc2) {
+  toml_result_t r1 = toml_parse(doc1, strlen(doc1));
+  toml_result_t r2 = toml_parse(doc2, strlen(doc2));
+  CHECK(r1.ok);
+  CHECK(r2.ok);
+  bool eq = toml_equiv(&r1, &r2);
+  toml_free(r1);
+  toml_free(r2);
+  return eq;
+}
+
+// Tables are unordered maps: same keys in a different order are equivalent.
+static void test_key_reorder() {
+  printf("Running test_key_reorder...\n");
+  CHECK(equiv("a = 1\nb = 2\n", "b = 2\na = 1\n"));
+}
+
+static void test_nested_reorder() {
+  printf("Running test_nested_reorder...\n");
+  const char *doc1 = "[t]\n"
+                     "x = 1\n"
+                     "y = 2\n";
+  const char *doc2 = "[t]\n"
+                     "y = 2\n"
+                     "x = 1\n";
+  CHECK(equiv(doc1, doc2));
+}
+
+// Keyvals and subtables may appear in any relative order.
+static void test_keyval_and_subtable_reorder() {
+  printf("Running test_keyval_and_subtable_reorder...\n");
+  const char *doc1 = "[t]\n"
+                     "a = 1\n"
+                     "[t.sub]\n"
+                     "b = 2\n";
+  const char *doc2 = "[t.sub]\n"
+                     "b = 2\n"
+                     "[t]\n"
+                     "a = 1\n";
+  CHECK(equiv(doc1, doc2));
+}
+
+static void test_different_value() {
+  printf("Running test_different_value...\n");
+  CHECK(!equiv("a = 1\nb = 2\n", "a = 1\nb = 3\n"));
+}
+
+static void test_missing_key() {
+  printf("Running test_missing_key...\n");
+  CHECK(!equiv("a = 1\nb = 2\n", "a = 1\n"));
+}
+
+// Same size, different key names.
+static void test_different_key() {
+  printf("Running test_different_key...\n");
+  CHECK(!equiv("a = 1\nb = 2\n", "a = 1\nc = 2\n"));
+}
+
+// Arrays stay order-sensitive.
+static void test_array_order_matters() {
+  printf("Running test_array_order_matters...\n");
+  CHECK(equiv("x = [1, 2, 3]\n", "x = [1, 2, 3]\n"));
+  CHECK(!equiv("x = [1, 2, 3]\n", "x = [3, 2, 1]\n"));
+}
+
+int main() {
+  test_key_reorder();
+  test_nested_reorder();
+  test_keyval_and_subtable_reorder();
+  test_different_value();
+  test_missing_key();
+  test_different_key();
+  test_array_order_matters();
+
+  printf("All tests completed.\n");
+  return 0;
+}


### PR DESCRIPTION
The TOML spec states key/value pairs within a table are not guaranteed to be in any specific order (https://toml.io/en/v1.0.0#table), so toml_equiv must match keys by name, not by position. Two tables with the same keys in a different order now compare equal. Add test/equiv covering key reorder, nested reorder, and negative cases (differing value, missing key, differing key name).