### PR TITLE
expose datum flag bit values as TOML_FLAG_* in public header

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -177,11 +177,6 @@ struct keypart_t {
 static int utf8_to_ucs(const char *s, int len, uint32_t *ret);
 static int ucs_to_utf8(uint32_t code, char buf[4]);
 
-// flags for toml_datum_t::flag.
-#define FLAG_INLINED 1
-#define FLAG_STDEXPR 2
-#define FLAG_EXPLICIT 4
-
 // Maximum levels of brackets and braces to prevent
 // stack overflow during recursive descent of the parser.
 #define BRACKET_LEVEL_MAX 30
@@ -1225,7 +1220,7 @@ static toml_datum_t *descend_keypart(parser_t *pp, int lineno, int colno,
     // Not found: add a new (key, tab) pair.
     if (j < 0) {
       toml_datum_t newtab = mkdatum_at(TOML_TABLE, lineno, colno);
-      newtab.flag |= stdtabexpr ? FLAG_STDEXPR : 0;
+      newtab.flag |= stdtabexpr ? TOML_FLAG_STDEXPR : 0;
       if (tab_add(tab, keypart->span[i], newtab, &reason)) {
         SETERROR(pp->ebuf, lineno, "%s", reason);
         return NULL;
@@ -1350,7 +1345,7 @@ static int parse_inline_array(parser_t *pp, token_t tok,
   }
 
   // Set the INLINE flag for all things in this array.
-  set_flag_recursive(ret_datum, FLAG_INLINED);
+  set_flag_recursive(ret_datum, TOML_FLAG_INLINED);
   return 0;
 }
 
@@ -1416,12 +1411,12 @@ static int parse_inline_table(parser_t *pp, token_t tok,
     }
 
     // If tab is a previously declared inline table: error.
-    if (tab->flag & FLAG_INLINED) {
+    if (tab->flag & TOML_FLAG_INLINED) {
       return SETERROR(pp->ebuf, tok.lineno, "inline table cannot be extended");
     }
 
     // We are explicitly defining it now.
-    tab->flag |= FLAG_EXPLICIT;
+    tab->flag |= TOML_FLAG_EXPLICIT;
 
     // match EQUAL
     DO(scan_value(&pp->scanner, &tok));
@@ -1451,7 +1446,7 @@ static int parse_inline_table(parser_t *pp, token_t tok,
     need_comma = 1, was_comma = 0;
   }
 
-  set_flag_recursive(ret_datum, FLAG_INLINED);
+  set_flag_recursive(ret_datum, TOML_FLAG_INLINED);
   return 0;
 }
 
@@ -1523,12 +1518,12 @@ static int parse_std_table_expr(parser_t *pp, token_t tok) {
   int j = tab_find(tab, lastkeypart);
   if (j < 0) {
     // If not found: add it.
-    if (tab->flag & FLAG_INLINED) {
+    if (tab->flag & TOML_FLAG_INLINED) {
       return SETERROR(pp->ebuf, keylineno, "inline table cannot be extended");
     }
     const char *reason;
     toml_datum_t newtab = mkdatum_at(TOML_TABLE, keylineno, keycolno);
-    newtab.flag |= FLAG_STDEXPR;
+    newtab.flag |= TOML_FLAG_STDEXPR;
     if (tab_add(tab, lastkeypart, newtab, &reason)) {
       return SETERROR(pp->ebuf, keylineno, "%s", reason);
     }
@@ -1537,7 +1532,7 @@ static int parse_std_table_expr(parser_t *pp, token_t tok) {
   } else {
     // Found: check for errors
     tab = &tab->u.tab.value[j];
-    if (tab->flag & FLAG_EXPLICIT) {
+    if (tab->flag & TOML_FLAG_EXPLICIT) {
       /*
         This is not OK:
         [x.y.z]
@@ -1549,7 +1544,7 @@ static int parse_std_table_expr(parser_t *pp, token_t tok) {
       */
       return SETERROR(pp->ebuf, keylineno, "table defined more than once");
     }
-    if (!(tab->flag & FLAG_STDEXPR)) {
+    if (!(tab->flag & TOML_FLAG_STDEXPR)) {
       /*
       [t1]			# OK
       t2.t3.v = 0		# OK
@@ -1561,7 +1556,7 @@ static int parse_std_table_expr(parser_t *pp, token_t tok) {
   }
 
   // Set explicit flag on tab
-  tab->flag |= FLAG_EXPLICIT;
+  tab->flag |= TOML_FLAG_EXPLICIT;
   tab->lineno = keylineno;
   tab->colno = keycolno;
 
@@ -1607,7 +1602,7 @@ static int parse_array_table_expr(parser_t *pp, token_t tok) {
   int idx = tab_find(tab, lastkeypart);
   if (idx == -1) {
     // If not found, add an array of table.
-    if (tab->flag & FLAG_INLINED) {
+    if (tab->flag & TOML_FLAG_INLINED) {
       return SETERROR(pp->ebuf, keylineno, "inline table cannot be extended");
     }
     toml_datum_t newarr = mkdatum_at(TOML_ARRAY, keylineno, keycolno);
@@ -1623,7 +1618,7 @@ static int parse_array_table_expr(parser_t *pp, token_t tok) {
   }
   // Add an empty table to the array
   toml_datum_t *arr = &tab->u.tab.value[idx];
-  if (arr->flag & FLAG_INLINED) {
+  if (arr->flag & TOML_FLAG_INLINED) {
     return SETERROR(pp->ebuf, keylineno, "cannot extend a static array");
   }
   toml_datum_t *pelem = arr_emplace(arr, &reason);
@@ -1659,7 +1654,7 @@ static int parse_keyvalue_expr(parser_t *pp, token_t tok) {
   for (int i = 0; i < keypart.nspan - 1; i++) {
     int j = tab_find(tab, keypart.span[i]);
     if (j < 0) {
-      if (i > 0 && (tab->flag & FLAG_EXPLICIT)) {
+      if (i > 0 && (tab->flag & TOML_FLAG_EXPLICIT)) {
         return SETERROR(
             pp->ebuf, keylineno,
             "cannot extend a previously defined table using dotted expression");
@@ -1686,10 +1681,10 @@ static int parse_keyvalue_expr(parser_t *pp, token_t tok) {
   }
 
   // Check for disallowed situations.
-  if (tab->flag & FLAG_INLINED) {
+  if (tab->flag & TOML_FLAG_INLINED) {
     return SETERROR(pp->ebuf, keylineno, "inline table cannot be extended");
   }
-  if (keypart.nspan > 1 && (tab->flag & FLAG_EXPLICIT)) {
+  if (keypart.nspan > 1 && (tab->flag & TOML_FLAG_EXPLICIT)) {
     return SETERROR(
         pp->ebuf, keylineno,
         "cannot extend a previously defined table using dotted expression");

--- a/src/tomlc17.h
+++ b/src/tomlc17.h
@@ -99,6 +99,16 @@ struct toml_datum_t {
 };
 
 /**
+ * @brief Bit values for toml_datum_t::flag.
+ *
+ * These record how a datum appeared in the source document. They are set
+ * by the parser and are informational for API users.
+ */
+#define TOML_FLAG_INLINED 1  /**< appeared in inline form, e.g. {x = 1} or [1, 2] */
+#define TOML_FLAG_STDEXPR 2  /**< table created by a [table] header */
+#define TOML_FLAG_EXPLICIT 4 /**< table explicitly defined */
+
+/**
  * @brief Result of a TOML parsing operation.
  */
 typedef struct toml_result_t toml_result_t;


### PR DESCRIPTION
I am aware these flags are documented as internal, but they can help with writing a serializer on top of tomlc17. #11 mentions that serialization is out of scope for this library, but exposing these can help writing one that can write back a file parsed by tomlc17 in a similar format.

Alternatively I can just redefine them in my serialization code, if you do not want to make them public.