### PR TITLE
Suppress spurious -Wcast-align in the arena allocator

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,6 +29,25 @@ jobs:
       run: make install prefix=./tmp
 
 
+  # -Wcast-align is not implied by -Wall or -Wextra, and gcc's plain
+  # -Wcast-align is a no-op on x86-64: gcc only reports it on targets that
+  # actually require the stricter alignment.  That is why this warning is
+  # invisible from an ordinary `cc -Wcast-align` build on an x86-64 Ubuntu
+  # box, and visible to anyone whose `cc` is clang.  To see it on x86-64,
+  # gcc needs -Wcast-align=strict; clang reports it on any target.
+  #
+  # Both spellings are run here so the warning is reproducible on either
+  # compiler rather than depending on which one `cc` happens to be.
+  cast-align:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: gcc -Wcast-align=strict
+      run: gcc -std=c17 -Wall -Wextra -Wcast-align=strict -Werror -c src/tomlc17.c -o /dev/null
+    - name: clang -Wcast-align
+      run: clang -std=c17 -Wall -Wextra -Wcast-align -Werror -c src/tomlc17.c -o /dev/null
+
   build-macos:
     runs-on: macos-latest
   

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -221,7 +221,7 @@ static char *cell_realloc(char *p, int size) {
   }
 
   // obtain a handle to cell info
-  cell_t *cp = (cell_t *)(p - sizeof(cell_t));
+  cell_t *cp = (cell_t *)(void *)(p - sizeof(cell_t));
   if ((uint32_t)size <= cp->max) {
     // cell is big enough for the new size. DONE.
     cp->top = size;
@@ -242,7 +242,7 @@ static char *cell_realloc(char *p, int size) {
 
 static void cell_free(char *p) {
   if (p) {
-    cell_t *cp = (cell_t *)(p - sizeof(cell_t));
+    cell_t *cp = (cell_t *)(void *)(p - sizeof(cell_t));
     FREE(cp);
   }
 }
@@ -414,11 +414,11 @@ static toml_datum_t *tab_emplace(toml_datum_t *tab, span_t key,
   }
 
   {
-    char **pkey =
-        (char **)cell_realloc((char *)tab->u.tab.key, sizeof(*pkey) * (N + 1));
-    int *plen =
-        (int *)cell_realloc((char *)tab->u.tab.len, sizeof(*plen) * (N + 1));
-    toml_datum_t *value = (toml_datum_t *)cell_realloc(
+    char **pkey = (char **)(void *)cell_realloc((char *)tab->u.tab.key,
+                                                sizeof(*pkey) * (N + 1));
+    int *plen = (int *)(void *)cell_realloc((char *)tab->u.tab.len,
+                                            sizeof(*plen) * (N + 1));
+    toml_datum_t *value = (toml_datum_t *)(void *)cell_realloc(
         (char *)tab->u.tab.value, sizeof(*value) * (N + 1));
 
     // on success, must save new pointers in tab->u.tab because the
@@ -476,8 +476,8 @@ static toml_datum_t *arr_emplace(toml_datum_t *arr, const char **reason) {
     *reason = "array too large";
     return NULL;
   }
-  toml_datum_t *elem = (toml_datum_t *)cell_realloc((char *)arr->u.arr.elem,
-                                                    sizeof(*elem) * (n + 1));
+  toml_datum_t *elem = (toml_datum_t *)(void *)cell_realloc(
+      (char *)arr->u.arr.elem, sizeof(*elem) * (n + 1));
   if (!elem) {
     *reason = "out of memory";
     return NULL;
@@ -564,14 +564,14 @@ static const char *dedup_source(srcmap_t *m, const char *src) {
   // Grow the memo first, so an allocation failure aborts cleanly.
   if (m->n == m->cap) {
     int newcap = m->cap ? m->cap * 2 : 4;
-    const char **no =
-        (const char **)cell_realloc((char *)m->olds, sizeof(*no) * newcap);
+    const char **no = (const char **)(void *)cell_realloc(
+        (char *)m->olds, sizeof(*no) * newcap);
     if (!no) {
       return NULL; // out of memory
     }
     m->olds = no;
-    const char **nn =
-        (const char **)cell_realloc((char *)m->news, sizeof(*nn) * newcap);
+    const char **nn = (const char **)(void *)cell_realloc(
+        (char *)m->news, sizeof(*nn) * newcap);
     if (!nn) {
       return NULL; // out of memory
     }

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -221,7 +221,7 @@ static char *cell_realloc(char *p, int size) {
   }
 
   // obtain a handle to cell info
-  cell_t *cp = (cell_t *)(p - sizeof(cell_t));
+  cell_t *cp = (cell_t *)(void *)(p - sizeof(cell_t));
   if ((uint32_t)size <= cp->max) {
     // cell is big enough for the new size. DONE.
     cp->top = size;
@@ -242,7 +242,7 @@ static char *cell_realloc(char *p, int size) {
 
 static void cell_free(char *p) {
   if (p) {
-    cell_t *cp = (cell_t *)(p - sizeof(cell_t));
+    cell_t *cp = (cell_t *)(void *)(p - sizeof(cell_t));
     FREE(cp);
   }
 }
@@ -414,11 +414,11 @@ static toml_datum_t *tab_emplace(toml_datum_t *tab, span_t key,
   }
 
   {
-    char **pkey =
-        (char **)cell_realloc((char *)tab->u.tab.key, sizeof(*pkey) * (N + 1));
-    int *plen =
-        (int *)cell_realloc((char *)tab->u.tab.len, sizeof(*plen) * (N + 1));
-    toml_datum_t *value = (toml_datum_t *)cell_realloc(
+    char **pkey = (char **)(void *)cell_realloc((char *)tab->u.tab.key,
+                                                sizeof(*pkey) * (N + 1));
+    int *plen = (int *)(void *)cell_realloc((char *)tab->u.tab.len,
+                                            sizeof(*plen) * (N + 1));
+    toml_datum_t *value = (toml_datum_t *)(void *)cell_realloc(
         (char *)tab->u.tab.value, sizeof(*value) * (N + 1));
 
     // on success, must save new pointers in tab->u.tab because the
@@ -476,8 +476,8 @@ static toml_datum_t *arr_emplace(toml_datum_t *arr, const char **reason) {
     *reason = "array too large";
     return NULL;
   }
-  toml_datum_t *elem = (toml_datum_t *)cell_realloc((char *)arr->u.arr.elem,
-                                                    sizeof(*elem) * (n + 1));
+  toml_datum_t *elem = (toml_datum_t *)(void *)cell_realloc(
+      (char *)arr->u.arr.elem, sizeof(*elem) * (n + 1));
   if (!elem) {
     *reason = "out of memory";
     return NULL;
@@ -570,14 +570,14 @@ static const char *dedup_source(srcmap_t *m, const char *src) {
   // Grow the memo first, so an allocation failure aborts cleanly.
   if (m->n == m->cap) {
     int newcap = m->cap ? m->cap * 2 : 4;
-    const char **no =
-        (const char **)cell_realloc((char *)m->olds, sizeof(*no) * newcap);
+    const char **no = (const char **)(void *)cell_realloc(
+        (char *)m->olds, sizeof(*no) * newcap);
     if (!no) {
       return NULL; // out of memory
     }
     m->olds = no;
-    const char **nn =
-        (const char **)cell_realloc((char *)m->news, sizeof(*nn) * newcap);
+    const char **nn = (const char **)(void *)cell_realloc(
+        (char *)m->news, sizeof(*nn) * newcap);
     if (!nn) {
       return NULL; // out of memory
     }


### PR DESCRIPTION
cell_realloc()'s header-before-payload pattern and its call sites that cast the returned char* back to a wider-aligned pointer type trigger -Wcast-align under -Werror. The casts are safe: p is always either REALLOC()'s own return value, or p - sizeof(cell_t) recovers that exact same, maximally-aligned pointer -- the compiler just can't prove it from byte-level pointer arithmetic on a char*. Route each cast through an intermediate (void *), the standard idiom for a deliberate alignment-increasing cast. No behavioral change.