### PR TITLE
fix: check both dst and src for array-of-tables in datum_merge

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -695,7 +695,7 @@ static int datum_merge(toml_datum_t *dst, toml_datum_t src, srcmap_t *sm,
     }
     return 0;
   case TOML_ARRAY:
-    if (is_array_of_tables(src)) {
+    if (is_array_of_tables(*dst) && is_array_of_tables(src)) {
       // append src array to dst
       for (int i = 0; i < src.u.arr.size; i++) {
         toml_datum_t *pelem = arr_emplace(dst, reason);

--- a/test/merge/test1.c
+++ b/test/merge/test1.c
@@ -142,6 +142,30 @@ static void test_array_of_tables() {
   check(doc1, doc2, expected);
 }
 
+// A plain array overridden by an array of tables must be fully replaced,
+// not have table elements appended onto the plain values.
+static void test_plain_array_overridden_by_array_of_tables() {
+  printf("Running test_plain_array_overridden_by_array_of_tables...\n");
+  const char *doc1 = "arr = [1, 2, 3]";
+  const char *doc2 = "[[arr]]\n"
+                     "x = 1";
+  const char *expected = "[[arr]]\n"
+                         "x = 1";
+  check(doc1, doc2, expected);
+}
+
+// The reverse direction: an array of tables overridden by a plain array
+// must also be fully replaced, not have plain values appended onto the
+// table elements.
+static void test_array_of_tables_overridden_by_plain_array() {
+  printf("Running test_array_of_tables_overridden_by_plain_array...\n");
+  const char *doc1 = "[[arr]]\n"
+                     "x = 1";
+  const char *doc2 = "arr = [9, 8]";
+  const char *expected = "arr = [9, 8]";
+  check(doc1, doc2, expected);
+}
+
 static void test_type_conflicts() {
   printf("Running test_type_conflicts...\n");
   const char *doc1 = "value = 42";
@@ -191,6 +215,8 @@ int main() {
   test_deep_merge();
   test_complex_merge();
   test_array_of_tables();
+  test_plain_array_overridden_by_array_of_tables();
+  test_array_of_tables_overridden_by_plain_array();
   test_type_conflicts();
   test_empty_documents();
   test_keys_outlive_inputs();


### PR DESCRIPTION
## Bug

In \`datum_merge()\`'s \`TOML_ARRAY\` case (\`src/tomlc17.c\`), whether to *append* src onto dst (rather than *override* dst with src) is decided by:

\`\`\`c
if (is_array_of_tables(src)) {
\`\`\`

Per the documented merge algorithm in \`src/tomlc17.h\`:

> elif x in ret is an array of tables: append r2.x to ret.x

("ret" is dst, from r1) the check should be about **dst**, not src.

Checking only `src` means: if dst is a plain array (e.g. `arr = [1, 2, 3]`) and src is an array of tables (e.g. `[[arr]]\nx = 1`), the code appends src's table element onto dst's existing array instead of overriding it. The result is a single `TOML_ARRAY` with a mix of scalar and table elements, e.g. size 4 with elements `INT64(1), INT64(2), INT64(3), TABLE` — not the clean override the documented semantics call for.

## Fix

Require **both** sides to already be arrays-of-tables before appending:

\`\`\`c
if (is_array_of_tables(*dst) && is_array_of_tables(src)) {
\`\`\`

Checking `dst` alone is not sufficient — it fixes the case above, but flips the same bug into the opposite direction: dst = array-of-tables, src = plain array would then also wrongly append (mixing a table element with plain values) instead of overriding. The double-sided check keeps the existing "append when both sides are genuinely arrays-of-tables" behavior intact, and makes every other combination fall through to override, matching the documented algorithm in both directions.

## Testing

Added two regression tests to \`test/merge/test1.c\` covering both directions (plain array overridden by array-of-tables, and array-of-tables overridden by plain array). All 12 tests in \`test/merge/test1.c\` (10 existing + 2 new) pass with no regressions:

\`\`\`
$ ./test1
Running test_simple_merge...
Running test_overwrite_values...
Running test_nested_tables...
Running test_array_merging...
Running test_deep_merge...
Running test_complex_merge...
Running test_array_of_tables...
Running test_plain_array_overridden_by_array_of_tables...
Running test_array_of_tables_overridden_by_plain_array...
Running test_type_conflicts...
Running test_empty_documents...
Running test_keys_outlive_inputs...
All tests completed.
\`\`\`