### PR TITLE
Strip a leading UTF-8 BOM, and keep U+FEFF out of bare keys

### DIFF
--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -1069,6 +1069,15 @@ toml_result_t toml_parse_named(const char *src, int len, const char *name) {
     goto bail;
   }
 
+  // A UTF-8 BOM at the very start is an encoding artifact rather than content,
+  // so drop it before scanning. Everywhere else U+FEFF stays exactly as it is
+  // and remains an error, which is what bom-not-at-start expects.
+  if (len >= 3 && (unsigned char)src[0] == 0xEF && (unsigned char)src[1] == 0xBB &&
+      (unsigned char)src[2] == 0xBF) {
+    src += 3;
+    len -= 3;
+  }
+
   // If user insists, check that src[] is a valid utf8 string.
   if (toml_option.check_utf8) {
     int line = 1; // keeps track of line number
@@ -2867,7 +2876,7 @@ static bool is_unicode_bare_key_char(uint32_t cp) {
   if (0xF900 <= cp && cp <= 0xFDCF)
     return true;
   if (0xFDF0 <= cp && cp <= 0xFFFD)
-    return true;
+    return cp != 0xFEFF; // BOM: stripped when leading, an error anywhere else
   if (0x10000 <= cp && cp <= 0xEFFFF)
     return true;
   return false;


### PR DESCRIPTION
Three `toml-test` cases fail on `main`, all with the same cause:

```
FAIL valid/utf8-bom-01
FAIL valid/utf8-bom-02
FAIL invalid/encoding/bom-not-at-start-03
```

The v1.1 bare-key set includes `U+FDF0`–`U+FFFD` (the XML 1.1 `NameChar` ranges, as documented in BAREKEYCHAR.md), and **U+FEFF falls inside it**. So the byte order mark is scanned as an ordinary bare-key character rather than recognised as encoding.

What that does to a file saved as UTF-8 with BOM, which is the default in several Windows editors:

```
\xEF\xBB\xBFa=1   parses to   { "﻿a": 1 }      expected { "a": 1 }
```

No error is reported. Every top-level key silently carries an invisible prefix, so `toml_get(root, "a")` returns nothing and the document reads as empty. `utf8-bom-01` fails more visibly — the BOM starts a key, the comment that follows is not `=`, and it errors with `(line 1) expect '='`. And two BOMs are accepted as the key `"﻿﻿a"`, where the second one has to be an error.

### The change

Two things, both small:

* drop a BOM at offset 0 in `toml_parse_named`
* exclude `U+FEFF` from `is_unicode_bare_key_char`

`U+FEFF` anywhere else is left exactly as it was.

### Verified

`make test`, with `toml-test` built from `toml-lang/toml-test@main`:

| | before | after |
|---|---|---|
| valid | 218 passed, **2 failed** | **220 passed, 0 failed** |
| invalid | 490 passed, **1 failed** | **491 passed, 0 failed** |

Checked that the fix does not overreach:

| case | result |
|---|---|
| `"﻿quoted" = 1` (BOM inside a quoted key) | preserved |
| `other = "a﻿b"` (BOM inside a string value) | preserved |
| `ﷰ = 1` (the codepoint next to the excluded one) | still a valid bare key |

### Not a regression

The README's *"As of Dec 25, 2025, all tests passed for TOML v1.1"* was accurate. These three cases arrived later — `toml-lang/toml-test`, 2026-05-07, *"Fix invalid BOM tests, add valid UTF-8 BOM test"* — so this is new upstream coverage rather than something that broke.

### One judgement call worth your eye

I stripped the BOM in `toml_parse_named` rather than in the scanner, so it applies to every entry point and the scanner keeps a single notion of what a key character is. The alternative — handling it in the scanner's first-token path — keeps `toml_parse_named` free of encoding concerns but puts a position-dependent special case into the scanner. I took the first because the rule really is positional (offset 0 only) and that is a property of the document, not of the token stream. Happy to move it if you would rather the scanner owned it.
