### PR TITLE
Decide scan_float()'s ERANGE result on the bit pattern, not FP comparisons

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,6 +29,27 @@ jobs:
       run: make install prefix=./tmp
 
 
+  # scan_float() must not depend on floating-point semantics a fast-math
+  # build is free to change: such builds may assume no operand is subnormal
+  # and every operand is finite, which is what broke the subnormal check
+  # under Intel icx -fp-model=fast (issue #49, PR #50).  -ffast-math is the
+  # closest gcc equivalent, and it also sets FTZ+DAZ at process start, so
+  # this job covers the run-time flags as well as the compile-time ones.
+  build-ubuntu-fastmath:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        cache: false
+    - name: install toml-test
+      run: go install github.com/toml-lang/toml-test/v2/cmd/toml-test@latest
+    - name: make clean all
+      run: make clean all EXTRA_CFLAGS="-ffast-math"
+    - name: make test
+      run: make test EXTRA_CFLAGS="-ffast-math"
+
   build-macos:
     runs-on: macos-latest
   

--- a/simple/Makefile
+++ b/simple/Makefile
@@ -12,6 +12,7 @@ endif
 ifneq ($(OS), Windows_NT)
     CFLAGS += -fpic
 endif
+CFLAGS += $(EXTRA_CFLAGS)
 
 CXXFLAGS = $(subst -std=c17,-std=c++20,$(CFLAGS))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,7 @@ endif
 ifneq ($(OS), Windows_NT)
     CFLAGS += -fpic
 endif
+CFLAGS += $(EXTRA_CFLAGS)
 
 
 all: $(EXEC) $(LIB) $(LIB_SHARED) 

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -2673,16 +2673,21 @@ static int scan_float(scanner_t *sp, token_t *tok) {
   char *q;
   double fp64 = strtod(buffer, &q);
   // glibc sets ERANGE on underflow even when strtod's result is correctly
-  // rounded, e.g. 5e-324; allow acceptance of such subnormal results.  Test
-  // the raw bit pattern rather than "fp64 != 0.0": under flush-to-zero mode
-  // (enabled by default at -O2 and above by some compilers, e.g. Intel's
-  // icc/icx via -fp-model=fast unless -fp-model=precise is given), the CPU
-  // treats a genuinely nonzero subnormal operand as 0.0 for the purposes of
-  // an SSE floating-point comparison, without altering the value in memory.
-  // An integer comparison against the bit pattern is immune to that.
+  // rounded, e.g. 5e-324; accept such results, but still reject a value that
+  // underflowed to zero or overflowed to infinity.  Decide on the raw bit
+  // pattern rather than with "fp64 != 0.0" and isfinite(): a fast-math build
+  // (gcc/clang -ffast-math or -ffinite-math-only, Intel icx -fp-model=fast,
+  // its default at -O2 and above) may assume that no operand is subnormal
+  // and that every operand is finite, folding isfinite() to 1 and evaluating
+  // the comparison as if a subnormal were zero -- and FTZ/DAZ can flush
+  // subnormals in SSE operations at run time.  Integer tests on the bits
+  // depend on neither.
+  static_assert(sizeof(fp64) == sizeof(uint64_t), "double must be 64 bits");
   uint64_t fp64_bits;
-  memcpy(&fp64_bits, &fp64, sizeof(fp64_bits));
-  int is_ok_subnormal = (errno == ERANGE) && fp64_bits != 0 && isfinite(fp64);
+  memcpy(&fp64_bits, &fp64, sizeof(fp64));
+  uint64_t fp64_mag = fp64_bits & 0x7fffffffffffffffULL; // drop the sign bit
+  int is_ok_subnormal =
+      (errno == ERANGE) && fp64_mag != 0 && fp64_mag < 0x7ff0000000000000ULL;
   if ((errno && !is_ok_subnormal) || *q || q == buffer) {
     return SETERROR(sp->ebuf, lineno, "error parsing float");
   }

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -2673,8 +2673,16 @@ static int scan_float(scanner_t *sp, token_t *tok) {
   char *q;
   double fp64 = strtod(buffer, &q);
   // glibc sets ERANGE on underflow even when strtod's result is correctly
-  // rounded, e.g. 5e-324; allow acceptance of such subnormal results.
-  int is_ok_subnormal = (errno == ERANGE) && fp64 != 0.0 && isfinite(fp64);
+  // rounded, e.g. 5e-324; allow acceptance of such subnormal results.  Test
+  // the raw bit pattern rather than "fp64 != 0.0": under flush-to-zero mode
+  // (enabled by default at -O2 and above by some compilers, e.g. Intel's
+  // icc/icx via -fp-model=fast unless -fp-model=precise is given), the CPU
+  // treats a genuinely nonzero subnormal operand as 0.0 for the purposes of
+  // an SSE floating-point comparison, without altering the value in memory.
+  // An integer comparison against the bit pattern is immune to that.
+  uint64_t fp64_bits;
+  memcpy(&fp64_bits, &fp64, sizeof(fp64_bits));
+  int is_ok_subnormal = (errno == ERANGE) && fp64_bits != 0 && isfinite(fp64);
   if ((errno && !is_ok_subnormal) || *q || q == buffer) {
     return SETERROR(sp->ebuf, lineno, "error parsing float");
   }

--- a/src/tomlc17.c
+++ b/src/tomlc17.c
@@ -2675,13 +2675,22 @@ static int scan_float(scanner_t *sp, token_t *tok) {
   // glibc sets ERANGE on underflow even when strtod's result is correctly
   // rounded, e.g. 5e-324; accept such results, but still reject a value that
   // underflowed to zero or overflowed to infinity.  Decide on the raw bit
-  // pattern rather than with "fp64 != 0.0" and isfinite(): a fast-math build
-  // (gcc/clang -ffast-math or -ffinite-math-only, Intel icx -fp-model=fast,
-  // its default at -O2 and above) may assume that no operand is subnormal
-  // and that every operand is finite, folding isfinite() to 1 and evaluating
-  // the comparison as if a subnormal were zero -- and FTZ/DAZ can flush
-  // subnormals in SSE operations at run time.  Integer tests on the bits
-  // depend on neither.
+  // pattern rather than with "fp64 != 0.0" and isfinite(), each of which
+  // fails in its own way:
+  //
+  //   - denormals-are-zero (DAZ, MXCSR bit 6) makes an SSE compare read a
+  //     subnormal operand as 0.0, so "fp64 != 0.0" is false for a value the
+  //     conversion got right.  This is the reported bug (issue #49): with
+  //     DAZ set the old check rejects 5e-324, and with only flush-to-zero
+  //     (FTZ, bit 15) set it does not -- FTZ acts on results, DAZ on inputs.
+  //     Toolchains that enable DAZ process-wide include Intel icc/icx under
+  //     -fp-model=fast, their default at -O2 and above, and gcc/clang under
+  //     -ffast-math, which links a startup that sets it.
+  //
+  //   - isfinite() is folded to 1 by gcc and clang under -ffast-math and
+  //     -ffinite-math-only, which would let an overflow to infinity through.
+  //
+  // Integer tests on the bits depend on neither.
   static_assert(sizeof(fp64) == sizeof(uint64_t), "double must be 64 bits");
   uint64_t fp64_bits;
   memcpy(&fp64_bits, &fp64, sizeof(fp64));

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -6,6 +6,7 @@ ifdef DEBUG
 else
     CFLAGS += -O3 -DNDEBUG
 endif
+CFLAGS += $(EXTRA_CFLAGS)
 
 CXXFLAGS = $(subst -std=c17,-std=c++20,$(CFLAGS))
 

--- a/test/equiv/Makefile
+++ b/test/equiv/Makefile
@@ -1,6 +1,7 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD
 
 EXEC = test1
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: $(EXEC)
 

--- a/test/merge/Makefile
+++ b/test/merge/Makefile
@@ -1,6 +1,7 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD
 
 EXEC = test1
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: $(EXEC)
 

--- a/test/parser/Makefile
+++ b/test/parser/Makefile
@@ -1,4 +1,5 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD 
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: driver
 

--- a/test/pool/Makefile
+++ b/test/pool/Makefile
@@ -1,6 +1,7 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD
 
 EXEC = test1
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: $(EXEC)
 

--- a/test/scankey/Makefile
+++ b/test/scankey/Makefile
@@ -1,4 +1,5 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD 
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: driver
 

--- a/test/scanvalue/Makefile
+++ b/test/scanvalue/Makefile
@@ -1,4 +1,5 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD 
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: driver
 

--- a/test/scanvalue/good/e3.out
+++ b/test/scanvalue/good/e3.out
@@ -1,0 +1,3 @@
+ENDL 28 1 _
+EQUAL 29 1 =
+(line 2) error parsing float

--- a/test/scanvalue/good/e4.out
+++ b/test/scanvalue/good/e4.out
@@ -1,0 +1,3 @@
+ENDL 22 1 _
+EQUAL 23 1 =
+(line 2) error parsing float

--- a/test/scanvalue/in/e3
+++ b/test/scanvalue/in/e3
@@ -1,0 +1,2 @@
+# underflow to negative zero
+= -1e-400

--- a/test/scanvalue/in/e4
+++ b/test/scanvalue/in/e4
@@ -1,0 +1,2 @@
+# overflow to infinity
+= 1e400

--- a/test/source/Makefile
+++ b/test/source/Makefile
@@ -1,6 +1,7 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD
 
 EXEC = test1
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: $(EXEC)
 

--- a/test/stdtest/Makefile
+++ b/test/stdtest/Makefile
@@ -1,4 +1,5 @@
 CFLAGS := -O0 -g -fsanitize=address,undefined -std=c17 -Wmissing-declarations -Wall -Wextra -MMD 
+CFLAGS += $(EXTRA_CFLAGS)
 
 all: driver
 


### PR DESCRIPTION
Fixes #49.

`is_ok_subnormal` in `scan_float()` (added by #48 / 64a063b) compares the parsed value with a floating-point `!=` operator:

```c
int is_ok_subnormal = (errno == ERANGE) && fp64 != 0.0 && isfinite(fp64);
```

Under flush-to-zero (FTZ) mode — the default for Intel's icc/icx at `-O2` and above via `-fp-model=fast`, unless `-fp-model=precise`/`-fp-model=strict` is given — an SSE floating-point comparison against a genuinely nonzero subnormal operand is performed as if it were `0.0`, without changing the value in memory. `is_ok_subnormal` then evaluates false and the parser rejects a valid float literal like `x = 5e-324` with `error parsing float`, even though `strtod()` returned the correctly rounded value.

This PR swaps the comparison for a bit-pattern check, which is unaffected by FTZ/DAZ hardware state:

```c
uint64_t fp64_bits;
memcpy(&fp64_bits, &fp64, sizeof(fp64_bits));
int is_ok_subnormal = (errno == ERANGE) && fp64_bits != 0 && isfinite(fp64);
```

Verified locally by forcing FTZ+DAZ via SSE intrinsics around a small harness exercising `scan_float()`/`toml_parse()`: the boundary subnormal literals fail to parse before this change and parse correctly after it. Ran the existing suite (`make test`) with the fix applied — `scankey`, `scanvalue`, `parser`, `merge`, `cpp`, `source`, `equiv`, and `pool` all pass (`stdtest` needs `go`/`toml-test`, not available in my environment, so I couldn't exercise it either way).

I didn't add a new test case to `test/scanvalue`'s data-driven harness, since that harness doesn't set FTZ/DAZ and so can't actually exercise this bug (it would just prove subnormal literals still parse under normal FPU state, which #48 already covers). Happy to add a small dedicated test that forces FTZ via SSE intrinsics if that's useful — wanted to check preference first rather than guess at test infra conventions.
